### PR TITLE
Refactor price fields in sell page form

### DIFF
--- a/ArtGalleryProject/src/frontend/src/pages/sell.jsx
+++ b/ArtGalleryProject/src/frontend/src/pages/sell.jsx
@@ -12,8 +12,7 @@ const Sell = () => {
     description: "",
     length: "",
     breadth: "",
-    startingPrice: "",
-    fixedPrice: "",
+    price: "",
   });
 
   const handleChange = (e) => {
@@ -265,7 +264,7 @@ const Sell = () => {
                   </label>
                   <input
                     type="number"
-                    name="Price"
+                    name="price"
                     required
                     min="0"
                     step="any"
@@ -281,7 +280,7 @@ const Sell = () => {
                   </label>
                   <input
                     type="number"
-                    name="Price"
+                    name="price"
                     required
                     min="0"
                     step="any"


### PR DESCRIPTION
Replaces 'startingPrice' and 'fixedPrice' with a single 'price' field in the sell page form and updates input field names to match. This simplifies the form data structure and ensures consistency in naming.